### PR TITLE
fix: 🐛 make sql queries not load excessive data and load in known order

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -28,15 +28,16 @@ pub fn create_chat(
 }
 
 pub fn get_chat(connection: &mut PgConnection, chat_id: &Uuid) -> QueryResult<Chat> {
-    chats::dsl::chats.find(chat_id).first::<Chat>(connection)
+    chats::dsl::chats.find(chat_id).first(connection)
 }
 
 pub fn get_chat_messages(
     connection: &mut PgConnection,
     chat_id: &Uuid,
 ) -> QueryResult<Vec<Message>> {
-    let messages: Vec<RecordedMessage> = messages::dsl::messages
+    let messages = messages::dsl::messages
         .filter(messages::dsl::chat_id.eq(chat_id))
+        .order(messages::dsl::created_at.asc())
         .load::<RecordedMessage>(connection)?;
     messages
         .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,11 +42,9 @@ async fn start(db: PgDatabase) -> Result<Json<StartResponse>, ApiError> {
         .run(|connection| {
             // Flip a coin to determine if android is going be a defect
             let is_defective = rand::thread_rng().gen_bool(0.5);
-            let defect = if is_defective {
-                let category = Categories::select_random(connection)?;
-                Some(Defect::select_random_from_category(connection, &category)?)
-            } else {
-                None
+            let defect = match is_defective {
+                true => Some(Defect::select_random_from_category(connection, &category)?),
+                false => None,
             };
             let persona = Persona::select_random_persona(connection)?;
             let name: String = Name().fake();

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,11 @@ async fn start(db: PgDatabase) -> Result<Json<StartResponse>, ApiError> {
         .run(|connection| {
             // Flip a coin to determine if android is going be a defect
             let is_defective = rand::thread_rng().gen_bool(0.5);
-            let category = Categories::select_random(connection)?;
-            let defect = match is_defective {
-                true => Some(Defect::select_random_from_category(connection, &category)?),
-                false => None,
+            let defect = if is_defective {
+                let category = Categories::select_random(connection)?;
+                Some(Defect::select_random_from_category(connection, &category)?)
+            } else {
+                None
             };
             let persona = Persona::select_random_persona(connection)?;
             let name: String = Name().fake();

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,10 @@ async fn start(db: PgDatabase) -> Result<Json<StartResponse>, ApiError> {
             // Flip a coin to determine if android is going be a defect
             let is_defective = rand::thread_rng().gen_bool(0.5);
             let defect = match is_defective {
-                true => Some(Defect::select_random_from_category(connection, &category)?),
+                true => {
+                    let category = Categories::select_random(connection)?;
+                    Some(Defect::select_random_from_category(connection, &category)?)
+                },
                 false => None,
             };
             let persona = Persona::select_random_persona(connection)?;

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -1,8 +1,7 @@
 use crate::schema::categories;
 use diesel::prelude::*;
-use rand::seq::SliceRandom;
 
-#[derive(Queryable, Clone, Debug)]
+#[derive(Queryable, QueryableByName, Clone, Debug)]
 #[diesel(table_name = categories)]
 pub struct Categories {
     pub id: i32,
@@ -11,10 +10,8 @@ pub struct Categories {
 
 impl Categories {
     pub fn select_random(connection: &mut PgConnection) -> QueryResult<Self> {
-        let categories = categories::dsl::categories.load::<Categories>(connection)?;
-        let chosen = categories
-            .choose(&mut rand::thread_rng())
-            .ok_or(diesel::result::Error::NotFound)?;
-        Ok(chosen.clone())
+        let category = diesel::sql_query("SELECT * FROM categories OFFSET floor(random() * (SELECT count(1) from categories)) LIMIT 1")
+            .get_result::<Self>(connection)?;
+        Ok(category.clone())
     }
 }

--- a/src/models/persona.rs
+++ b/src/models/persona.rs
@@ -1,8 +1,7 @@
 use crate::schema::personas;
 use diesel::prelude::*;
-use rand::seq::SliceRandom;
 
-#[derive(Queryable, Debug)]
+#[derive(Queryable, Debug, QueryableByName)]
 #[diesel(table_name = personas)]
 pub struct Persona {
     pub id: i32,
@@ -11,10 +10,8 @@ pub struct Persona {
 
 impl Persona {
     pub fn select_random_persona(connection: &mut PgConnection) -> QueryResult<String> {
-        let personas = personas::dsl::personas.load::<Self>(connection)?;
-        let persona = personas
-            .choose(&mut rand::thread_rng())
-            .ok_or(diesel::result::Error::NotFound)?;
-        Ok(persona.text.clone())
+        let persona = diesel::sql_query("SELECT * FROM personas OFFSET floor(random() * (SELECT count(1) from personas)) LIMIT 1")
+            .get_result::<Self>(connection)?;
+        Ok(persona.text.to_owned())
     }
 }


### PR DESCRIPTION
Loading 5 records then discarding 4? waste of precious memory.

I wrote it to not use the superior `TABLESAMPLE` in [postgres](https://www.postgresql.org/docs/current/sql-select.html) so that cockroach (which you are using for db, yes?) could still parse.

I wanted to write some truely awful expression to make the offset subquery work without writing sql, but diesel did not allow it.